### PR TITLE
Implement Windows resident wake-word service

### DIFF
--- a/agents/resident/windows/README.md
+++ b/agents/resident/windows/README.md
@@ -1,0 +1,62 @@
+# Heystive Windows Resident Wake-Word Service
+
+This directory contains the Windows-specific implementation of the Heystive resident wake-word service that keeps the assistant listening in the background.
+
+## Files
+
+- `watcher_win.py` - Main wake-word detection service
+- `run_resident.bat` - Batch launcher script
+- `install_task.ps1` - PowerShell script to install as Windows scheduled task
+- `uninstall_task.ps1` - PowerShell script to remove the scheduled task
+
+## Quick Start
+
+1. **Install dependencies:**
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. **Start the unified server:**
+   ```bash
+   python server/main.py
+   ```
+
+3. **Test the watcher manually:**
+   ```bash
+   python agents\resident\windows\watcher_win.py
+   ```
+
+4. **Install as auto-start service:**
+   ```powershell
+   powershell -ExecutionPolicy Bypass -File agents\resident\windows\install_task.ps1
+   ```
+
+5. **Uninstall the service:**
+   ```powershell
+   powershell -ExecutionPolicy Bypass -File agents\resident\windows\uninstall_task.ps1
+   ```
+
+## Configuration
+
+The service reads configuration from the Heystive settings API at `http://127.0.0.1:8765/api/settings`:
+
+- `wakeword_enabled` (bool) - Enable/disable wake-word detection
+- `wakeword_keyword` (str) - Wake-word phrase (default: "hey steve")
+- `wakeword_sensitivity` (float) - Detection sensitivity 0.1-0.9 (default: 0.5)
+- `wakeword_device_index` (int|null) - Audio device index (null for system default)
+
+## Features
+
+- **Local processing** - No cloud calls, all processing happens locally
+- **Voice Activity Detection** - Uses WebRTC VAD to filter out non-speech audio
+- **Debouncing** - Prevents multiple triggers within 5 seconds
+- **Dynamic configuration** - Settings changes apply without restart
+- **Low CPU usage** - Optimized for background operation
+- **Auto-start** - Installs as Windows scheduled task for automatic startup
+
+## Privacy & Security
+
+- All audio processing is local
+- No data is sent to external services
+- Only communicates with local Heystive server
+- Can be completely disabled via settings or uninstalled

--- a/agents/resident/windows/install_task.ps1
+++ b/agents/resident/windows/install_task.ps1
@@ -1,0 +1,11 @@
+$ErrorActionPreference = "Stop"
+$TaskName = "HeystiveResident"
+$RepoRoot = (Resolve-Path "$PSScriptRoot\..\..\..").Path
+$BatPath = Join-Path $RepoRoot "agents\resident\windows\run_resident.bat"
+if (-not (Test-Path $BatPath)) { throw "run_resident.bat not found at $BatPath" }
+$Action = New-ScheduledTaskAction -Execute "cmd.exe" -Argument "/c `"$BatPath`""
+$Trigger = New-ScheduledTaskTrigger -AtLogOn
+$Settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -MultipleInstances IgnoreNew
+try { Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue } catch {}
+Register-ScheduledTask -TaskName $TaskName -Action $Action -Trigger $Trigger -Settings $Settings -Description "Heystive resident wake-word listener" -Force
+Write-Host "Installed task '$TaskName'. It will start on next logon."

--- a/agents/resident/windows/run_resident.bat
+++ b/agents/resident/windows/run_resident.bat
@@ -1,0 +1,7 @@
+@echo off
+setlocal
+set "REPO=%~dp0..\..\.."
+pushd "%REPO%"
+start "" /B pythonw "agents\resident\windows\watcher_win.py"
+popd
+endlocal

--- a/agents/resident/windows/uninstall_task.ps1
+++ b/agents/resident/windows/uninstall_task.ps1
@@ -1,0 +1,4 @@
+$ErrorActionPreference = "Stop"
+$TaskName = "HeystiveResident"
+Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
+Write-Host "Removed task '$TaskName'."

--- a/agents/resident/windows/watcher_win.py
+++ b/agents/resident/windows/watcher_win.py
@@ -1,0 +1,91 @@
+import time, threading, queue, requests, numpy as np
+import sounddevice as sd
+import webrtcvad
+from openwakeword import Model
+
+BASE = "http://127.0.0.1:8765"
+CFG = {"enabled": True, "keyword": "hey steve", "sensitivity": 0.5, "device": None}
+RUN = True
+
+def fetch_settings():
+    try:
+        r = requests.get(f"{BASE}/api/settings", timeout=3)
+        s = r.json()
+        CFG["enabled"] = bool(s.get("wakeword_enabled", True))
+        CFG["keyword"] = s.get("wakeword_keyword", "hey steve")
+        CFG["sensitivity"] = float(s.get("wakeword_sensitivity", 0.5))
+        CFG["device"] = s.get("wakeword_device_index", None)
+    except Exception:
+        pass
+
+def pick_label(scores: dict, key_hint: str):
+    kh = key_hint.strip().lower()
+    best = None
+    bestv = 0.0
+    for k, v in scores.items():
+        if kh in k.lower():
+            if v > bestv:
+                best, bestv = k, v
+    if best is None:
+        for k, v in scores.items():
+            if v > bestv:
+                best, bestv = k, v
+    return best, bestv
+
+def audio_stream(q, device):
+    sr = 16000
+    bs = 8000
+    def cb(indata, frames, time_info, status):
+        try:
+            q.put(indata.copy())
+        except Exception:
+            pass
+    with sd.InputStream(callback=cb, channels=1, samplerate=sr, blocksize=bs, dtype="float32", device=device):
+        while RUN:
+            time.sleep(0.05)
+
+def main():
+    fetch_settings()
+    vad = webrtcvad.Vad(2)
+    mdl = Model(trigger_level=CFG["sensitivity"])
+    last = 0.0
+    q = queue.Queue(maxsize=8)
+    t = threading.Thread(target=audio_stream, args=(q, CFG["device"]), daemon=True)
+    t.start()
+    buf = bytes()
+    sr = 16000
+    frame_ms = 20
+    frame_bytes = int(sr/1000*frame_ms)*2
+    while RUN:
+        try:
+            fetch_settings()
+            if not CFG["enabled"]:
+                time.sleep(0.5)
+                continue
+            chunk = q.get(timeout=1)
+            pcm16 = np.clip(chunk[:,0]*32767, -32768, 32767).astype(np.int16).tobytes()
+            buf += pcm16
+            while len(buf) >= frame_bytes:
+                frame = buf[:frame_bytes]
+                buf = buf[frame_bytes:]
+                if not vad.is_speech(frame, sr):
+                    continue
+                y = np.frombuffer(frame, dtype=np.int16).astype(np.float32)/32767.0
+                scores = mdl.predict(y)
+                label, score = pick_label(scores, CFG["keyword"])
+                if score >= CFG["sensitivity"]:
+                    now = time.time()
+                    if now - last > 5.0:
+                        try:
+                            requests.post(f"{BASE}/api/intent", json={"text":"listen"}, timeout=2)
+                        except Exception:
+                            pass
+                        last = now
+        except Exception:
+            time.sleep(0.1)
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        RUN = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ librosa==0.10.1
 soundfile==0.13.1  # RESOLVED: Using newer version 0.13.1 (enhanced branch) for better compatibility
 webrtcvad==2.0.10
 pydub==0.25.1
+openwakeword==0.5.0
 
 # Speech Recognition & Synthesis
 openai-whisper==20231117

--- a/server/settings_store.py
+++ b/server/settings_store.py
@@ -24,6 +24,11 @@ class Settings(BaseModel):
     voice_enabled: bool = True
     tts_enabled: bool = True
     stt_enabled: bool = True
+    # Wake-word configuration
+    wakeword_enabled: bool = True
+    wakeword_keyword: str = "hey steve"
+    wakeword_sensitivity: float = 0.5
+    wakeword_device_index: int = None
 
 def read_settings() -> Dict[str, Any]:
     """Read settings from file"""


### PR DESCRIPTION
Add a Windows resident wake-word service for always-on background listening.

This PR introduces a self-contained, Windows-only resident wake-word service that keeps Heystive listening in the background and triggers `{"text":"listen"}` when the wake-word is detected. It integrates with the existing `/api/settings` for dynamic configuration and uses Windows Task Scheduler for auto-start at user logon, providing a local and privacy-focused hands-free interaction.

---
<a href="https://cursor.com/background-agent?bcId=bc-212d6ec9-4bd0-4391-ad3c-c9de19a9141e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-212d6ec9-4bd0-4391-ad3c-c9de19a9141e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

